### PR TITLE
AuthAPIを追加「会員登録、ログイン、ログアウト」

### DIFF
--- a/web/app/Http/Controllers/Auth/LoginController.php
+++ b/web/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
 
 class LoginController extends Controller
 {
@@ -36,5 +37,10 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    protected function authenticated(Request $request, $user)
+    {
+        return $user;
     }
 }

--- a/web/app/Http/Controllers/Auth/LoginController.php
+++ b/web/app/Http/Controllers/Auth/LoginController.php
@@ -43,4 +43,11 @@ class LoginController extends Controller
     {
         return $user;
     }
+
+    protected function loggedOut(Request $request)
+    {
+        $request->session()->regenerate();
+
+        return response()->json();
+    }
 }

--- a/web/app/Http/Controllers/Auth/RegisterController.php
+++ b/web/app/Http/Controllers/Auth/RegisterController.php
@@ -8,6 +8,7 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Http\Request;
 
 class RegisterController extends Controller
 {
@@ -69,5 +70,10 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    protected function registerd(Request $request, $user)
+    {
+        return $user;
     }
 }

--- a/web/app/Providers/RouteServiceProvider.php
+++ b/web/app/Providers/RouteServiceProvider.php
@@ -73,7 +73,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::prefix('api')
-             ->middleware('api')
+             ->middleware('web')
              ->namespace($this->namespace)
              ->group(base_path('routes/api.php'));
     }

--- a/web/config/database.php
+++ b/web/config/database.php
@@ -43,6 +43,12 @@ return [
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],
 
+        'sqlite_testing' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DATABASE_URL'),

--- a/web/phpunit.xml
+++ b/web/phpunit.xml
@@ -19,6 +19,7 @@
     </filter>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite_testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="sqlite"/>

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -16,3 +16,7 @@ use Illuminate\Http\Request;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post('/register', 'Auth\RegisterController@register')->name('register');
+
+Route::post('/login', 'Auth\LoginController@login')->name('login');

--- a/web/routes/api.php
+++ b/web/routes/api.php
@@ -13,10 +13,12 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+// Route::middleware('auth:api')->get('/user', function (Request $request) {
+//     return $request->user();
+// });
 
 Route::post('/register', 'Auth\RegisterController@register')->name('register');
 
 Route::post('/login', 'Auth\LoginController@login')->name('login');
+
+Route::post('/logout', 'Auth\LoginController@logout')->name('logout');

--- a/web/tests/Feature/LoginApiTest.php
+++ b/web/tests/Feature/LoginApiTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class LoginApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * test
+     */
+    public function should_登録済みのユーザーを認証して返却する()
+    {
+        $response = $this->json('POST', route('login'),[
+            'email' => $this->user->email,
+            'password' => 'password',
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson(['name' => $this->user->name]);
+        
+        $this->assertAuthenticatedAs($this->user);
+    }
+}

--- a/web/tests/Feature/LogoutApiTest.php
+++ b/web/tests/Feature/LogoutApiTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class LogoutApiTest extends TestCase
+{
+  use RefreshDatabase;
+
+  public function setUp(): void
+  {
+      parent::setUp();
+
+      // テストユーザーを作成
+      $this->user = factory(User::class)->create();
+  }
+
+  /**
+   * test
+   */
+  public function should_認証済みのユーザーをログアウトさせる()
+  {
+      $response = $this->actingAs($this->user)
+                       ->json('POST', route('logout'));
+
+      $response->assertStatus(200);
+      $this->assertGuest();
+  }
+}

--- a/web/tests/Feature/RegisterApiTest.php
+++ b/web/tests/Feature/RegisterApiTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class RegisterApiTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+   public function should_新しいユーザーを作成して返却する()
+   {
+       $data = [
+           'name' => 'vuesplash user',
+           'email' => 'dummy@email.com',
+           'password' => 'test 1234',
+           'password_confirmation' => 'test1234'
+       ];
+
+       $response = $this->json('POST', route('register'), $data);
+
+       $user = User::first();
+       $this->assertEquals($data['name'], $user->name);
+
+       $response
+            ->asserStatus(201)
+            ->assertJson(['name' => $user->name]);
+   }
+}


### PR DESCRIPTION
## API用Routeをapi.phpに定義
apiと画面のruote定義は別々のファイルに書いたほうがわかりやすい

**RouteServiceProvider.php**：アプリケーションの起動時にルート定義を読み込むためのクラス
```
protected function mapApiRoutes()
{
    Route::prefix('api')
         ->middleware('web')
         ->namespace($this->namespace)
         ->group(base_path('routes/api.php'));
}
```

ミドルウェアグループの定義は app/Http/Kernel.php に記述される、

---------

## テストコード（お試し）
SQLiteのデータベースを使うための設定を行う
インメモリのSQLiteを使うため、テスト実行が終わると削除されるのでムダにデータを残さなくて済む

**config/database.php_connections**
```
'sqlite_testing' => [
    'driver' => 'sqlite',
    'database' => ':memory:',
    'prefix' => '',
],
```

DB接続設定
phpunit.xml に DB 接続の設定を追記
```
<php>
<env name="DB_CONNECTION" value="sqlite_testing"/> 
...
```

----------

## 会員登録API
Request：name email password password_confirmationを受け取る
Response：登録成功後は登録ユーザーの情報を返却（ユーザーデータはフロントエンドで保存）

テストコード（webコンテナ内）
```
php artisan make:test RegisterApiTest
```



